### PR TITLE
Refactor PDF processing dependencies into injectable services

### DIFF
--- a/sources/pdf_processing/__init__.py
+++ b/sources/pdf_processing/__init__.py
@@ -1,23 +1,47 @@
 from .image_processor import pdf_to_image
+from .services import ClassifierService, OcrService, SentenceSegmenter
 from .tdata_extractor import image_to_tdata
 from .text_extractor import image_to_text
 
 import gc
 import torch
 
-def pdf_to_tdata(pdf_path):
-    # Process all pages and consolidate results for training dataset
+
+def pdf_to_tdata(
+    pdf_path,
+    *,
+    ocr_service: OcrService | None = None,
+    sentence_segmenter: SentenceSegmenter | None = None,
+):
     pages = pdf_to_image(pdf_path)
-    processed_text = image_to_tdata(pages)
+    processed_text = image_to_tdata(
+        pages,
+        ocr_service=ocr_service,
+        sentence_segmenter=sentence_segmenter,
+    )
 
     clear_memory()
     return processed_text
 
 
-def pdf_to_text(pdf_path, model_path):
-    # Process all pages, extract and classify the sentences
+def pdf_to_text(
+    pdf_path,
+    model_path,
+    *,
+    ocr_service: OcrService | None = None,
+    sentence_segmenter: SentenceSegmenter | None = None,
+    classifier_service: ClassifierService | None = None,
+    batch_size: int = 32,
+):
     pages = pdf_to_image(pdf_path)
-    processed_text = image_to_text(pages, model_path)
+    processed_text = image_to_text(
+        pages,
+        model_path,
+        ocr_service=ocr_service,
+        sentence_segmenter=sentence_segmenter,
+        classifier_service=classifier_service,
+        batch_size=batch_size,
+    )
 
     clear_memory()
     return [line for line, label in processed_text if label == 1]

--- a/sources/pdf_processing/image_processor.py
+++ b/sources/pdf_processing/image_processor.py
@@ -1,13 +1,11 @@
 from pdf2image import convert_from_path
-from paddleocr import PaddleOCR
 
 DPI = 300
-OCR = PaddleOCR(lang='en')  # Use 'multilingual' for multi-language PDFs
+
 
 def pdf_to_image(pdf_path):
     """Extract and consolidate text from a PDF, labeling compliance statements."""
     try:
-        # Convert PDF to images (keep colors for highlight detection)
         pages = convert_from_path(pdf_path, dpi=DPI)
     except Exception as e:
         print(f"Error converting PDF to images: {e}")

--- a/sources/pdf_processing/services.py
+++ b/sources/pdf_processing/services.py
@@ -1,0 +1,140 @@
+"""Service classes encapsulating NLP and OCR dependencies."""
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from paddleocr import PaddleOCR
+import spacy
+from torch import cuda
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+
+class OcrService:
+    """Wraps :class:`paddleocr.PaddleOCR` lifecycle management."""
+
+    def __init__(
+        self,
+        ocr: Optional[PaddleOCR] = None,
+        *,
+        lang: str = "en",
+        ocr_factory: Optional[Callable[..., PaddleOCR]] = None,
+        **ocr_kwargs,
+    ) -> None:
+        factory = ocr_factory or PaddleOCR
+        self._ocr = ocr or factory(lang=lang, **ocr_kwargs)
+
+    def ocr(self, image: np.ndarray, *, cls: bool = False):
+        return self._ocr.ocr(image, cls=cls)
+
+
+class SentenceSegmenter:
+    """Provides spaCy-backed sentence segmentation."""
+
+    def __init__(
+        self,
+        nlp=None,
+        *,
+        model_name: str = "en_core_web_sm",
+        nlp_loader: Optional[Callable[[str], spacy.language.Language]] = None,
+    ) -> None:
+        loader = nlp_loader or spacy.load
+        self._nlp = nlp or loader(model_name)
+
+    def segment(self, text: str) -> spacy.tokens.Doc:
+        return self._nlp(text)
+
+
+class ClassifierService:
+    """Handles loading and inference for transformer-based classifiers."""
+
+    def __init__(
+        self,
+        model=None,
+        tokenizer=None,
+        *,
+        model_name: Optional[str] = None,
+        device: Optional[str] = None,
+        model_loader: Optional[
+            Callable[[str, str], Tuple[torch.nn.Module, AutoTokenizer]]
+        ] = None,
+    ) -> None:
+        self._device = device or ("cuda" if cuda.is_available() else "cpu")
+        loader = model_loader or self._default_loader
+
+        if model is None or tokenizer is None:
+            if not model_name:
+                raise ValueError(
+                    "Either an existing model/tokenizer or model_name must be provided."
+                )
+            model, tokenizer = loader(model_name, self._device)
+        else:
+            model = model.to(self._device)
+
+        self._model = model
+        self._tokenizer = tokenizer
+
+    @staticmethod
+    def _default_loader(model_name: str, device: str):
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModelForSequenceClassification.from_pretrained(model_name)
+        return model.to(device), tokenizer
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    def classify(self, sentences: Sequence[str], batch_size: int = 32) -> List[int]:
+        predictions: List[int] = [0] * len(sentences)
+        valid_entries: List[Tuple[int, str]] = [
+            (idx, sentence)
+            for idx, sentence in enumerate(sentences)
+            if isinstance(sentence, str) and sentence.strip()
+        ]
+
+        if not valid_entries:
+            return predictions
+
+        model = self._model
+        tokenizer = self._tokenizer
+        device = self._device
+
+        batch: List[str] = []
+        batch_indices: List[int] = []
+
+        for idx, sentence in valid_entries:
+            batch.append(sentence)
+            batch_indices.append(idx)
+
+            if len(batch) == batch_size:
+                self._classify_batch(batch, batch_indices, predictions, model, tokenizer, device)
+                batch, batch_indices = [], []
+
+        if batch:
+            self._classify_batch(batch, batch_indices, predictions, model, tokenizer, device)
+
+        return predictions
+
+    @staticmethod
+    def _classify_batch(
+        batch: Iterable[str],
+        indices: Sequence[int],
+        predictions: List[int],
+        model,
+        tokenizer,
+        device: str,
+    ) -> None:
+        tokenized_batch = tokenizer(
+            list(batch), truncation=True, padding="max_length", return_tensors="pt"
+        )
+        tokenized_batch = {k: v.to(device) for k, v in tokenized_batch.items()}
+
+        model.eval()
+        with torch.no_grad():
+            outputs = model(**tokenized_batch)
+            logits = outputs.logits
+            batch_predictions = logits.argmax(dim=-1).tolist()
+
+        for idx, prediction in zip(indices, batch_predictions):
+            predictions[idx] = prediction

--- a/sources/pdf_processing/tdata_extractor.py
+++ b/sources/pdf_processing/tdata_extractor.py
@@ -1,35 +1,48 @@
-from .image_processor import OCR
-from .sentence_processor import extract_bbox, segment_sentences
+from __future__ import annotations
 
-import numpy as np
+from typing import Iterable, List, Optional
+
 import cv2
-import spacy
+import numpy as np
 
-nlp = spacy.load("en_core_web_sm")  # Used for sentence segmentation
+from .sentence_processor import extract_bbox, segment_sentences
+from .services import OcrService, SentenceSegmenter
 
 
-def detect_highlighted_regions(image):
+def detect_highlighted_regions(image: np.ndarray) -> List[List[int]]:
     """Detect highlighted regions in the image using color detection."""
     hsv = cv2.cvtColor(image, cv2.COLOR_RGB2HSV)
     lower_highlight = np.array([90, 50, 200])
     upper_highlight = np.array([130, 255, 255])
     mask = cv2.inRange(hsv, lower_highlight, upper_highlight)
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    return [[x, y, x + w, y + h] for x, y, w, h in (cv2.boundingRect(contour) for contour in contours)]
+    return [
+        [x, y, x + w, y + h]
+        for x, y, w, h in (cv2.boundingRect(contour) for contour in contours)
+    ]
 
 
-def label_compliance_sentences(sentences, highlighted_boxes, iou_threshold=0.5):
-    """Label sentences as compliance_statement=1 or compliance_statement=0 based on IoU with highlighted regions."""
+def label_compliance_sentences(
+    sentences: Iterable[dict],
+    highlighted_boxes: Iterable[Iterable[int]],
+    iou_threshold: float = 0.5,
+) -> List[dict]:
+    """Label sentences as compliance_statement=1 or compliance_statement=0 based on IoU."""
+    highlighted_boxes = list(highlighted_boxes)
+
     for sentence in sentences:
-        if sentence["bounding_box"]:
-            x, y, x2, y2 = sentence["bounding_box"]
-            sentence["compliance_statement"] = int(any(
-                calculate_iou([x, y, x2, y2], [hx, hy, hx + hw, hy + hh]) > iou_threshold
-                for hx, hy, hw, hh in highlighted_boxes
-            ))
+        bbox = sentence.get("bounding_box")
+        if bbox:
+            x, y, x2, y2 = bbox
+            sentence["compliance_statement"] = int(
+                any(
+                    calculate_iou([x, y, x2, y2], [hx, hy, hx + hw, hy + hh]) > iou_threshold
+                    for hx, hy, hw, hh in highlighted_boxes
+                )
+            )
         else:
             sentence["compliance_statement"] = 0
-    return sentences
+    return list(sentences)
 
 
 def calculate_iou(box1, box2):
@@ -49,24 +62,26 @@ def calculate_iou(box1, box2):
     return intersection / union if union > 0 else 0
 
 
-def image_to_tdata(pages):
-    consolidated_results = []
-    
+def image_to_tdata(
+    pages,
+    *,
+    ocr_service: Optional[OcrService] = None,
+    sentence_segmenter: Optional[SentenceSegmenter] = None,
+) -> List[dict]:
+    ocr_service = ocr_service or OcrService()
+    sentence_segmenter = sentence_segmenter or SentenceSegmenter()
+
+    consolidated_results: List[dict] = []
+
     for page in pages:
-        # Convert page to NumPy array
         image = np.array(page)
 
-        # Extracts text and converts it into senteces
-        text_boxes = extract_bbox(image)
-        sentences = segment_sentences(text_boxes)
+        text_boxes = extract_bbox(image, ocr_service)
+        sentences = segment_sentences(text_boxes, sentence_segmenter)
 
         highlighted_boxes = detect_highlighted_regions(image)
-        # Detect highlighted regions 
         labeled_text = label_compliance_sentences(sentences, highlighted_boxes)
 
-        #print("test")
-
-        # Add labeled text to consolidated results
         consolidated_results.extend(labeled_text)
 
-    return consolidated_results 
+    return consolidated_results

--- a/sources/pdf_processing/text_extractor.py
+++ b/sources/pdf_processing/text_extractor.py
@@ -1,72 +1,37 @@
-from functools import lru_cache
+from __future__ import annotations
 
-from .image_processor import OCR
-from .sentence_processor import segment_sentences
-
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-from torch import cuda
-import torch
+from typing import List, Optional, Tuple
 
 import numpy as np
 
-
-@lru_cache(maxsize=1)
-def _load_model(model_path: str):
-    """Load and cache the classifier model and tokenizer."""
-
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
-    model = AutoModelForSequenceClassification.from_pretrained(model_path)
-    device = "cuda" if cuda.is_available() else "cpu"
-    model = model.to(device)
-    return model, tokenizer
+from .sentence_processor import extract_bbox, segment_sentences
+from .services import ClassifierService, OcrService, SentenceSegmenter
 
 
-def classify_sentences(model, tokenizer, sentences, batch_size=32):
-    """Classify sentences as compliant or not compliant in batches."""
-    device = model.device  # Automatically get the model's device
-    valid_sentences = [s for s in sentences if isinstance(s, str) and s.strip()]
-    predictions = []
+def image_to_text(
+    pages,
+    model_path: Optional[str] = None,
+    *,
+    ocr_service: Optional[OcrService] = None,
+    sentence_segmenter: Optional[SentenceSegmenter] = None,
+    classifier_service: Optional[ClassifierService] = None,
+    batch_size: int = 32,
+) -> List[Tuple[str, int]]:
+    if classifier_service is None:
+        if not model_path:
+            raise ValueError("model_path is required when classifier_service is not provided")
+        classifier_service = ClassifierService(model_name=model_path)
 
-    for i in range(0, len(valid_sentences), batch_size):
-        batch = valid_sentences[i:i + batch_size]
+    ocr_service = ocr_service or OcrService()
+    sentence_segmenter = sentence_segmenter or SentenceSegmenter()
 
-        # Tokenize the batch
-        tokenized_batch = tokenizer(batch, truncation=True, padding="max_length", return_tensors="pt")
-
-        # Move input tensors to the same device as the model
-        tokenized_batch = {k: v.to(device) for k, v in tokenized_batch.items()}
-
-        # Perform inference
-        with torch.no_grad():  # Disable gradient computation for inference
-            outputs = model(**tokenized_batch)
-            logits = outputs.logits
-            batch_predictions = logits.argmax(dim=-1).tolist()
-
-        predictions.extend(batch_predictions)
-
-    # Pair sentences with predictions
-    return [(sentence, label) for sentence, label in zip(valid_sentences, predictions)]
-
-
-def image_to_text(pages, model_path):
-    sentences = []
+    sentences: List[str] = []
 
     for page in pages:
-        print(f"Processing page: {page}")
         image = np.array(page)
-        ocr_results = OCR.ocr(image, cls=False)
+        text_boxes = extract_bbox(image, ocr_service)
+        segmented_sentences = segment_sentences(text_boxes, sentence_segmenter)
+        sentences.extend([record["text"] for record in segmented_sentences])
 
-        # Extract text content and bounding boxes
-        text_boxes = [(line[1][0], line[0]) for line in ocr_results[0]]
-
-        # Segment text into sentences
-        segmented_sentences = segment_sentences(text_boxes)
-
-        # Collect sentences for classification
-        sentences.extend([s[0] for s in segmented_sentences])  # Extract text content only
-    
-    model, tokenizer = _load_model(model_path)
-    classified_sentences = classify_sentences(model, tokenizer, sentences)
-    print(classified_sentences)
-
-    return classified_sentences
+    predictions = classifier_service.classify(sentences, batch_size=batch_size)
+    return list(zip(sentences, predictions))


### PR DESCRIPTION
## Summary
- add OcrService, SentenceSegmenter, and ClassifierService abstractions to manage OCR, NLP, and classifier resources
- refactor PDF processing modules to consume these services instead of module-level singletons
- expose dependency injection hooks in the public PDF processing entry points for alternate models or test doubles

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d30bbbb7308331b731cb99c3f56f59