### PR TITLE
Respect classifier bundle injection for PDF inference

### DIFF
--- a/sources/pdf_processing/__init__.py
+++ b/sources/pdf_processing/__init__.py
@@ -1,29 +1,122 @@
-from .image_processor import pdf_to_image
+"""High-level helpers for PDF processing workflows."""
+
+from __future__ import annotations
+
+import gc
+from typing import Callable, Optional, Union
+
+import torch
+
+from .image_processor import DEFAULT_DPI, pdf_to_image
+from .services import (
+    ClassifierBundle,
+    ClassifierService,
+    OcrService,
+    PdfProcessingFactory,
+    SentenceSegmenter,
+)
 from .tdata_extractor import image_to_tdata
 from .text_extractor import image_to_text
 
-import gc
-import torch
+DEFAULT_FACTORY = PdfProcessingFactory()
 
-def pdf_to_tdata(pdf_path):
-    # Process all pages and consolidate results for training dataset
-    pages = pdf_to_image(pdf_path)
-    processed_text = image_to_tdata(pages)
+
+def pdf_to_tdata(
+    pdf_path: str,
+    *,
+    ocr_service: Optional[OcrService] = None,
+    sentence_segmenter: Optional[SentenceSegmenter] = None,
+    factory: Optional[PdfProcessingFactory] = None,
+    dpi: int = DEFAULT_DPI,
+):
+    """Process a PDF into training data dictionaries."""
+
+    pages = pdf_to_image(pdf_path, dpi=dpi)
+    active_factory = factory or DEFAULT_FACTORY
+    ocr = ocr_service or active_factory.get_ocr_service()
+    segmenter = sentence_segmenter or active_factory.get_sentence_segmenter()
+
+    processed_text = image_to_tdata(pages, ocr, segmenter)
 
     clear_memory()
     return processed_text
 
 
-def pdf_to_text(pdf_path, model_path):
-    # Process all pages, extract and classify the sentences
-    pages = pdf_to_image(pdf_path)
-    processed_text = image_to_text(pages, model_path)
+def pdf_to_text(
+    pdf_path: str,
+    model_path: Optional[str] = None,
+    *,
+    classifier_bundle: Optional[ClassifierBundle] = None,
+    classifier_factory: Optional[Callable[[], ClassifierBundle]] = None,
+    classifier_service: Optional[ClassifierService] = None,
+    ocr_service: Optional[OcrService] = None,
+    sentence_segmenter: Optional[SentenceSegmenter] = None,
+    factory: Optional[PdfProcessingFactory] = None,
+    dpi: int = DEFAULT_DPI,
+    batch_size: int = 32,
+):
+    """Process a PDF into classified text lines."""
+
+    active_factory = factory or DEFAULT_FACTORY
+
+    classifier_source: Union[
+        ClassifierBundle,
+        Callable[[], ClassifierBundle],
+    ]
+
+    if classifier_factory is not None and any(
+        item is not None for item in (classifier_bundle, classifier_service)
+    ):
+        raise ValueError(
+            "Provide only one of classifier_factory, classifier_bundle, or classifier_service",
+        )
+
+    if classifier_factory is not None:
+        classifier_source = classifier_factory
+    else:
+        if classifier_bundle is None:
+            if classifier_service is not None:
+                classifier_bundle = classifier_service.bundle
+            else:
+                if model_path is None:
+                    raise ValueError(
+                        "model_path must be provided when classifier bundle is not supplied",
+                    )
+                classifier_bundle = active_factory.get_classifier_bundle(model_path)
+
+        classifier_source = classifier_bundle
+
+    ocr = ocr_service or active_factory.get_ocr_service()
+    segmenter = sentence_segmenter or active_factory.get_sentence_segmenter()
+
+    pages = pdf_to_image(pdf_path, dpi=dpi)
+    processed_text = image_to_text(
+        pages,
+        classifier_source,
+        ocr_service=ocr,
+        sentence_segmenter=segmenter,
+        batch_size=batch_size,
+    )
 
     clear_memory()
-    return [line for line, label in processed_text if label == 1]
+    return processed_text
 
 
 def clear_memory():
     """Release GPU memory and clean up resources."""
+
     torch.cuda.empty_cache()
     gc.collect()
+
+
+__all__ = [
+    "DEFAULT_FACTORY",
+    "ClassifierBundle",
+    "ClassifierService",
+    "OcrService",
+    "PdfProcessingFactory",
+    "SentenceSegmenter",
+    "clear_memory",
+    "pdf_to_tdata",
+    "pdf_to_text",
+]

--- a/sources/pdf_processing/image_processor.py
+++ b/sources/pdf_processing/image_processor.py
@@ -1,16 +1,20 @@
+"""Utilities for converting PDF documents into image pages."""
+
+from __future__ import annotations
+
 from pdf2image import convert_from_path
-from paddleocr import PaddleOCR
 
-DPI = 300
-OCR = PaddleOCR(lang='en')  # Use 'multilingual' for multi-language PDFs
+DEFAULT_DPI = 300
 
-def pdf_to_image(pdf_path):
-    """Extract and consolidate text from a PDF, labeling compliance statements."""
+
+def pdf_to_image(pdf_path: str, *, dpi: int = DEFAULT_DPI):
+    """Render a PDF into a list of PIL.Image pages."""
+
     try:
-        # Convert PDF to images (keep colors for highlight detection)
-        pages = convert_from_path(pdf_path, dpi=DPI)
-    except Exception as e:
-        print(f"Error converting PDF to images: {e}")
+        return convert_from_path(pdf_path, dpi=dpi)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"Error converting PDF to images: {exc}")
         return []
 
-    return pages
+
+__all__ = ["DEFAULT_DPI", "pdf_to_image"]

--- a/sources/pdf_processing/sentence_processor.py
+++ b/sources/pdf_processing/sentence_processor.py
@@ -1,29 +1,38 @@
-from .image_processor import OCR
+"""Utilities for working with OCR output and sentences."""
 
-import spacy
+from __future__ import annotations
 
-nlp = spacy.load("en_core_web_sm")  # Used for sentence segmentation
+from typing import TYPE_CHECKING, List, Sequence, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .services import OcrService, SentenceSegmenter
+
+TextBox = Tuple[str, Sequence[Sequence[float]]]
 
 
-def extract_bbox(image):
-    """Extract bounding boxes and text using OCR."""
-    ocr_results = OCR.ocr(image, cls=False)
-    
-    print(ocr_results)
+def extract_bbox(image, ocr_service: "OcrService") -> List[TextBox]:  # type: ignore[no-untyped-def]
+    """Extract bounding boxes and text using the provided OCR service."""
 
-    extracted_data = []
-    for line in ocr_results[0]:
-        if len(line) < 2:
-            continue  # Skip malformed OCR results
+    ocr_results = ocr_service.extract(image, cls=False)
+    if not ocr_results:
+        return []
 
-        bbox, (text, conf) = line
-        if text.strip():  # Ensure non-empty text
+    lines = ocr_results[0] if isinstance(ocr_results, list) else ocr_results
+    extracted_data: List[TextBox] = []
+    for line in lines:
+        if not isinstance(line, (list, tuple)) or len(line) < 2:
+            continue
+        bbox, info = line[0], line[1]
+        text = info[0] if isinstance(info, (list, tuple)) else ""
+        if isinstance(text, str) and text.strip():
             extracted_data.append((text, bbox))
-    
-    return extracted_data if extracted_data else None  # Avoid returning NULL
 
-def convert_bbox(paddle_bbox):
-    """Convert PaddleOCR bounding box format (4 points) to (x_min, y_min, x_max, y_max)."""
+    return extracted_data
+
+
+def convert_bbox(paddle_bbox: Sequence[Sequence[float]]):
+    """Convert PaddleOCR bounding box format to ``(x_min, y_min, x_max, y_max)``."""
+
     x_min = min(point[0] for point in paddle_bbox)
     y_min = min(point[1] for point in paddle_bbox)
     x_max = max(point[0] for point in paddle_bbox)
@@ -31,48 +40,16 @@ def convert_bbox(paddle_bbox):
     return [x_min, y_min, x_max, y_max]
 
 
-def segment_sentences(text_boxes):
-    sentences = []
-    words = [item[0] for item in text_boxes]  # Extract words only
-    bounding_boxes = [item[1] for item in text_boxes]  # Extract bounding boxes
+def segment_sentences(text_boxes: Sequence[TextBox], segmenter: "SentenceSegmenter"):
+    """Segment OCR text boxes into sentences using the provided segmenter."""
 
-    # Join words into a full text passage
-    full_text = " ".join(words)
-
-    # Use spaCy to split into sentences
-    doc = nlp(full_text)
-    for sent in doc.sents:
-        sentence_text = sent.text.strip()
-
-        # Find words that belong to this sentence
-        matched_boxes = []
-        for word, bbox in zip(words, bounding_boxes):
-            if word in sentence_text:
-                matched_boxes.append(bbox)
-
-        # Merge bounding boxes for sentence
-        if matched_boxes:
-            x_min = min(box[0][0] for box in matched_boxes)  # Left-most x
-            y_min = min(box[0][1] for box in matched_boxes)  # Top-most y
-            x_max = max(box[2][0] for box in matched_boxes)  # Right-most x
-            y_max = max(box[2][1] for box in matched_boxes)  # Bottom-most y
-
-            sentence_bbox = (x_min, y_min, x_max, y_max)
-        else:
-            sentence_bbox = None  # Avoid NULL values
-
-        # **Use dictionary instead of tuple**
-        sentences.append({
-            "text": sentence_text,
-            "bounding_box": sentence_bbox
-        })
-
-    return sentences
+    return segmenter.segment(text_boxes)
 
 
-def find_sentence_box(sentence, text_boxes):
-    """Find a bounding box that covers a given sentence based on text box locations."""
-    matching_boxes = [box["bounding_box"] for box in text_boxes if sentence in box["text"]]
+def find_sentence_box(sentence: str, text_boxes: Sequence[dict]):
+    """Find a bounding box that covers ``sentence`` based on text box locations."""
+
+    matching_boxes = [box["bounding_box"] for box in text_boxes if sentence in box.get("text", "")]
     if not matching_boxes:
         return None
     x_min = min(box[0] for box in matching_boxes)
@@ -80,3 +57,6 @@ def find_sentence_box(sentence, text_boxes):
     x_max = max(box[2] for box in matching_boxes)
     y_max = max(box[3] for box in matching_boxes)
     return [x_min, y_min, x_max, y_max]
+
+
+__all__ = ["TextBox", "convert_bbox", "extract_bbox", "find_sentence_box", "segment_sentences"]

--- a/sources/pdf_processing/services.py
+++ b/sources/pdf_processing/services.py
@@ -1,0 +1,220 @@
+"""Service objects for PDF processing dependencies.
+
+This module exposes light-weight wrappers around heavyweight third-party
+libraries used throughout the PDF processing pipeline. Creating explicit
+services keeps resource-heavy objects (PaddleOCR, spaCy models, transformer
+models) out of module scope so they can be constructed lazily and injected
+where needed.  The :class:`PdfProcessingFactory` helper offers a convenient
+way to configure and cache shared service instances for orchestration code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+@dataclass
+class ClassifierBundle:
+    """Container for a tokenizer/model pair used during inference."""
+
+    tokenizer: Any
+    model: Any
+    device: str
+
+    def classify(self, sentences: Sequence[str], batch_size: int = 32) -> List[Tuple[str, int]]:
+        """Predict labels for ``sentences`` using the stored transformer bundle."""
+
+        import torch
+
+        valid_sentences = [s for s in sentences if isinstance(s, str) and s.strip()]
+        if not valid_sentences:
+            return []
+
+        predictions: List[int] = []
+        for start in range(0, len(valid_sentences), batch_size):
+            batch = valid_sentences[start : start + batch_size]
+            tokenized = self.tokenizer(
+                batch,
+                truncation=True,
+                padding="max_length",
+                return_tensors="pt",
+            )
+            tokenized = {key: value.to(self.device) for key, value in tokenized.items()}
+
+            with torch.no_grad():
+                outputs = self.model(**tokenized)
+                logits = outputs.logits
+                predictions.extend(logits.argmax(dim=-1).tolist())
+
+        return list(zip(valid_sentences, predictions))
+
+
+def _freeze_config(config: Any) -> Any:
+    """Recursively convert configuration objects into hashable structures."""
+
+    if isinstance(config, dict):
+        return tuple(sorted((key, _freeze_config(value)) for key, value in config.items()))
+    if isinstance(config, (list, tuple, set)):
+        return tuple(_freeze_config(value) for value in config)
+    return config
+
+
+class OcrService:
+    """Wrapper around :class:`paddleocr.PaddleOCR` for dependency injection."""
+
+    def __init__(self, *, lang: str = "en", **ocr_kwargs: Any) -> None:
+        from paddleocr import PaddleOCR
+
+        self._ocr = PaddleOCR(lang=lang, **ocr_kwargs)
+
+    def extract(self, image, **kwargs: Any):  # type: ignore[no-untyped-def]
+        """Run OCR on ``image`` and return PaddleOCR results."""
+
+        return self._ocr.ocr(image, **kwargs)
+
+
+class SentenceSegmenter:
+    """Sentence segmentation service backed by spaCy."""
+
+    def __init__(self, model: str = "en_core_web_sm", **load_kwargs: Any) -> None:
+        import spacy
+
+        self._nlp = spacy.load(model, **load_kwargs)
+
+    def segment(self, text_boxes: Sequence[Tuple[str, Sequence[Sequence[float]]]]):
+        """Convert OCR word boxes into sentence dictionaries with bounding boxes."""
+
+        words = [item[0] for item in text_boxes]
+        if not words:
+            return []
+        bounding_boxes = [item[1] for item in text_boxes]
+        full_text = " ".join(words)
+        doc = self._nlp(full_text)
+
+        sentences = []
+        for sent in doc.sents:
+            sentence_text = sent.text.strip()
+            if not sentence_text:
+                continue
+
+            matched_boxes = [
+                bbox
+                for word, bbox in zip(words, bounding_boxes)
+                if word and word in sentence_text
+            ]
+
+            if matched_boxes:
+                x_min = min(box[0][0] for box in matched_boxes)
+                y_min = min(box[0][1] for box in matched_boxes)
+                x_max = max(box[2][0] for box in matched_boxes)
+                y_max = max(box[2][1] for box in matched_boxes)
+                sentence_bbox = (x_min, y_min, x_max, y_max)
+            else:
+                sentence_bbox = None
+
+            sentences.append({"text": sentence_text, "bounding_box": sentence_bbox})
+
+        return sentences
+
+
+class ClassifierService:
+    """Transformer-based classifier wrapper used for inference."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        tokenizer_path: Optional[str] = None,
+        device: Optional[str] = None,
+        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        from torch import cuda
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+        tokenizer_kwargs = tokenizer_kwargs or {}
+        model_kwargs = model_kwargs or {}
+
+        tokenizer_source = tokenizer_path or model_path
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_source, **tokenizer_kwargs)
+        model = AutoModelForSequenceClassification.from_pretrained(model_path, **model_kwargs)
+
+        if device is None:
+            device = "cuda" if cuda.is_available() else "cpu"
+
+        model = model.to(device)
+        self._bundle = ClassifierBundle(tokenizer=tokenizer, model=model, device=device)
+
+    @property
+    def device(self) -> str:
+        return self._bundle.device
+
+    @property
+    def bundle(self) -> ClassifierBundle:
+        return self._bundle
+
+    def classify(self, sentences: Sequence[str], batch_size: int = 32) -> List[Tuple[str, int]]:
+        """Predict labels for ``sentences`` using the loaded transformer model."""
+
+        return self._bundle.classify(sentences, batch_size=batch_size)
+
+
+@dataclass
+class PdfProcessingFactory:
+    """Factory for creating and caching PDF processing services."""
+
+    ocr_kwargs: Dict[str, Any] = field(default_factory=dict)
+    segmenter_kwargs: Dict[str, Any] = field(default_factory=dict)
+    classifier_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    _ocr_service: Optional[OcrService] = field(init=False, default=None)
+    _sentence_segmenter: Optional[SentenceSegmenter] = field(init=False, default=None)
+    _classifier_cache: Dict[Any, ClassifierService] = field(init=False, default_factory=dict)
+
+    def get_ocr_service(self) -> OcrService:
+        if self._ocr_service is None:
+            self._ocr_service = OcrService(**self.ocr_kwargs)
+        return self._ocr_service
+
+    def get_sentence_segmenter(self) -> SentenceSegmenter:
+        if self._sentence_segmenter is None:
+            self._sentence_segmenter = SentenceSegmenter(**self.segmenter_kwargs)
+        return self._sentence_segmenter
+
+    def get_classifier_service(self, model_path: str, **overrides: Any) -> ClassifierService:
+        merged = {**self.classifier_kwargs, **overrides}
+        cache_key = (model_path, _freeze_config(merged))
+        if cache_key not in self._classifier_cache:
+            self._classifier_cache[cache_key] = ClassifierService(model_path, **merged)
+        return self._classifier_cache[cache_key]
+
+    def get_classifier_bundle(self, model_path: str, **overrides: Any) -> ClassifierBundle:
+        """Return a cached classifier bundle for ``model_path``."""
+
+        service = self.get_classifier_service(model_path, **overrides)
+        return service.bundle
+
+
+def create_ocr_service(**kwargs: Any) -> OcrService:
+    return OcrService(**kwargs)
+
+
+def create_sentence_segmenter(**kwargs: Any) -> SentenceSegmenter:
+    return SentenceSegmenter(**kwargs)
+
+
+def create_classifier_service(model_path: str, **kwargs: Any) -> ClassifierService:
+    return ClassifierService(model_path, **kwargs)
+
+
+__all__ = [
+    "ClassifierBundle",
+    "ClassifierService",
+    "OcrService",
+    "PdfProcessingFactory",
+    "SentenceSegmenter",
+    "create_classifier_service",
+    "create_ocr_service",
+    "create_sentence_segmenter",
+]

--- a/sources/pdf_processing/tdata_extractor.py
+++ b/sources/pdf_processing/tdata_extractor.py
@@ -1,72 +1,101 @@
-from .image_processor import OCR
+"""Utilities for turning PDF pages into labeled training data."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, List, Sequence
+
+import cv2
+import numpy as np
+
 from .sentence_processor import extract_bbox, segment_sentences
 
-import numpy as np
-import cv2
-import spacy
-
-nlp = spacy.load("en_core_web_sm")  # Used for sentence segmentation
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .services import OcrService, SentenceSegmenter
 
 
-def detect_highlighted_regions(image):
+def detect_highlighted_regions(image: np.ndarray) -> List[List[int]]:
     """Detect highlighted regions in the image using color detection."""
+
     hsv = cv2.cvtColor(image, cv2.COLOR_RGB2HSV)
     lower_highlight = np.array([90, 50, 200])
     upper_highlight = np.array([130, 255, 255])
     mask = cv2.inRange(hsv, lower_highlight, upper_highlight)
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    return [[x, y, x + w, y + h] for x, y, w, h in (cv2.boundingRect(contour) for contour in contours)]
+    return [
+        [x, y, x + w, y + h]
+        for x, y, w, h in (cv2.boundingRect(contour) for contour in contours)
+    ]
 
 
-def label_compliance_sentences(sentences, highlighted_boxes, iou_threshold=0.5):
-    """Label sentences as compliance_statement=1 or compliance_statement=0 based on IoU with highlighted regions."""
+def label_compliance_sentences(
+    sentences: List[dict],
+    highlighted_boxes: Sequence[Sequence[int]],
+    iou_threshold: float = 0.5,
+) -> List[dict]:
+    """Label sentences based on overlap with highlighted regions."""
+
     for sentence in sentences:
-        if sentence["bounding_box"]:
-            x, y, x2, y2 = sentence["bounding_box"]
-            sentence["compliance_statement"] = int(any(
-                calculate_iou([x, y, x2, y2], [hx, hy, hx + hw, hy + hh]) > iou_threshold
-                for hx, hy, hw, hh in highlighted_boxes
-            ))
+        bbox = sentence.get("bounding_box")
+        if bbox and len(bbox) == 4:
+            overlaps = [
+                calculate_iou(bbox, highlight_box) > iou_threshold
+                for highlight_box in highlighted_boxes
+            ]
+            sentence["compliance_statement"] = int(any(overlaps))
         else:
             sentence["compliance_statement"] = 0
     return sentences
 
 
-def calculate_iou(box1, box2):
+def calculate_iou(box1: Sequence[int], box2: Sequence[int]) -> float:
     """Calculate Intersection over Union (IoU) for two bounding boxes."""
-    if not box1 or not box2 or len(box1) != 4 or len(box2) != 4:
-        return 0
+
+    if len(box1) != 4 or len(box2) != 4:
+        return 0.0
+
     x1, y1 = max(box1[0], box2[0]), max(box1[1], box2[1])
     x2, y2 = min(box1[2], box2[2]), min(box1[3], box2[3])
 
     intersection = max(0, x2 - x1) * max(0, y2 - y1)
+    if intersection == 0:
+        return 0.0
 
     area1 = (box1[2] - box1[0]) * (box1[3] - box1[1])
     area2 = (box2[2] - box2[0]) * (box2[3] - box2[1])
-
     union = area1 + area2 - intersection
 
-    return intersection / union if union > 0 else 0
+    return intersection / union if union > 0 else 0.0
 
 
-def image_to_tdata(pages):
-    consolidated_results = []
-    
+def image_to_tdata(
+    pages: Iterable,
+    ocr_service: "OcrService",
+    sentence_segmenter: "SentenceSegmenter",
+) -> List[dict]:
+    """Convert PDF pages into labeled training data records."""
+
+    consolidated_results: List[dict] = []
+
     for page in pages:
-        # Convert page to NumPy array
         image = np.array(page)
+        text_boxes = extract_bbox(image, ocr_service)
+        if not text_boxes:
+            continue
 
-        # Extracts text and converts it into senteces
-        text_boxes = extract_bbox(image)
-        sentences = segment_sentences(text_boxes)
+        sentences = segment_sentences(text_boxes, sentence_segmenter)
+        if not sentences:
+            continue
 
         highlighted_boxes = detect_highlighted_regions(image)
-        # Detect highlighted regions 
         labeled_text = label_compliance_sentences(sentences, highlighted_boxes)
-
-        #print("test")
-
-        # Add labeled text to consolidated results
         consolidated_results.extend(labeled_text)
 
-    return consolidated_results 
+    return consolidated_results
+
+
+__all__ = [
+    "calculate_iou",
+    "detect_highlighted_regions",
+    "image_to_tdata",
+    "label_compliance_sentences",
+]

--- a/tests/test_pdf_processing_inference.py
+++ b/tests/test_pdf_processing_inference.py
@@ -1,0 +1,133 @@
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+if "cv2" not in sys.modules:
+    cv2_stub = types.SimpleNamespace(
+        cvtColor=lambda *args, **kwargs: None,
+        COLOR_RGB2HSV=0,
+        inRange=lambda *args, **kwargs: None,
+        RETR_EXTERNAL=0,
+        CHAIN_APPROX_SIMPLE=0,
+        findContours=lambda *args, **kwargs: ([], None),
+        boundingRect=lambda contour: (0, 0, 0, 0),
+    )
+    sys.modules["cv2"] = cv2_stub
+
+from sources.pdf_processing import pdf_to_text
+from sources.pdf_processing.text_extractor import image_to_text
+
+
+class DummyBundle:
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+
+    def classify(self, sentences, batch_size=32):
+        self.calls.append((list(sentences), batch_size))
+        return list(zip(sentences, range(len(sentences))))
+
+
+def test_image_to_text_returns_structured_results(monkeypatch):
+    pages = [np.zeros((1, 1))]
+
+    def fake_extract_bbox(image, ocr_service):
+        return [("sentence one", []), ("sentence two", [])]
+
+    def fake_segment_sentences(text_boxes, segmenter):
+        return [{"text": text} for text, _ in text_boxes]
+
+    monkeypatch.setattr(
+        "sources.pdf_processing.text_extractor.extract_bbox",
+        fake_extract_bbox,
+    )
+    monkeypatch.setattr(
+        "sources.pdf_processing.text_extractor.segment_sentences",
+        fake_segment_sentences,
+    )
+
+    bundle = DummyBundle("model-a")
+    results = image_to_text(
+        pages,
+        bundle,
+        ocr_service=object(),
+        sentence_segmenter=object(),
+        batch_size=4,
+    )
+
+    assert results == [
+        {"text": "sentence one", "label": 0},
+        {"text": "sentence two", "label": 1},
+    ]
+    assert bundle.calls == [(["sentence one", "sentence two"], 4)]
+
+    # verify callable sources are supported
+    bundle_callable = DummyBundle("model-b")
+
+    def factory():
+        return bundle_callable
+
+    results_callable = image_to_text(
+        pages,
+        factory,
+        ocr_service=object(),
+        sentence_segmenter=object(),
+        batch_size=2,
+    )
+
+    assert results_callable == [
+        {"text": "sentence one", "label": 0},
+        {"text": "sentence two", "label": 1},
+    ]
+    assert bundle_callable.calls == [(["sentence one", "sentence two"], 2)]
+
+
+def test_pdf_to_text_uses_requested_model_path(monkeypatch, tmp_path):
+    pdf_path = tmp_path / "document.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+
+    class DummyFactory:
+        def __init__(self):
+            self.requests = []
+
+        def get_classifier_bundle(self, model_path, **overrides):
+            bundle = DummyBundle(model_path)
+            self.requests.append((model_path, overrides))
+            return bundle
+
+        def get_ocr_service(self):
+            return object()
+
+        def get_sentence_segmenter(self):
+            return object()
+
+    factory = DummyFactory()
+
+    def fake_pdf_to_image(path, dpi=300):  # noqa: D401 - simple stub
+        assert Path(path) == pdf_path
+        return [np.zeros((1, 1))]
+
+    def fake_image_to_text(pages, classifier_source, **kwargs):
+        if callable(classifier_source):
+            bundle = classifier_source()
+        else:
+            bundle = classifier_source
+        return [{"text": f"{bundle.name}-text", "label": 1}]
+
+    import sources.pdf_processing as pdf_module
+
+    monkeypatch.setattr(pdf_module, "pdf_to_image", fake_pdf_to_image)
+    monkeypatch.setattr(pdf_module, "image_to_text", fake_image_to_text)
+
+    result_a = pdf_to_text(str(pdf_path), "model-a", factory=factory, batch_size=8)
+    result_b = pdf_to_text(str(pdf_path), "model-b", factory=factory)
+
+    assert factory.requests == [("model-a", {}), ("model-b", {})]
+    assert result_a == [{"text": "model-a-text", "label": 1}]
+    assert result_b == [{"text": "model-b-text", "label": 1}]


### PR DESCRIPTION
## Summary
- introduce a reusable `ClassifierBundle` with factory helpers so transformers can be injected as explicit model/tokenizer pairs
- update `image_to_text`/`pdf_to_text` to consume classifier bundles or factories, returning structured sentence+label results
- add pytest coverage that exercises multiple model directories and callable bundles to confirm inference wiring respects the requested model path

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2ff4b43a48331ba8858c9ee67f476