### PR TITLE
Refactor compliance pipeline orchestration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,59 +1,36 @@
-import config
 import os
-import json
-import numpy as np
 
-from sources.pdf_processing import pdf_to_tdata, pdf_to_text
-from sources.data_labeler import label_data
-from sources.model_trainer import train_model
+import config
+from sources.compliance_processor import CompliancePipeline, CompliancePipelineConfig
+from sources import pdf_processing
+from sources import data_labeler
+from sources import model_trainer
 
-TRAIN_FILES = os.listdir(config.LABELED_PDF_DIR)
-INPUT_FILES = os.listdir(config.INPUT_PDF_DIR)
-
-def default_handler(obj):
-    if isinstance(obj, np.floating):
-        return float(obj)
-    if isinstance(obj, np.integer):
-        return int(obj)
-    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
-
-def label_doc(text):
-    unlabeled_data = []
-    labeled_data = []
-
-    for element in text:
-        unlabeled_data.append({"compliance_statement":element["compliance_statement"], "compliance_data":None, "date":None, "business_entity": None, "regulation": None, "text": element["text"]}) 
-    
-    labeled_data = label_data(unlabeled_data)    
-
-    return labeled_data
-
-def process_tdata(files, input_path=config.LABELED_PDF_DIR, output_path=config.TRAINING_DATA_DIR):
-    for entry in files:
-        file_path = os.path.join(input_path, entry)
-        dataset_labeled = pdf_to_tdata(file_path)
-
-        # dataset_labeled = label_doc(dataset_raw)
-
-        training_dataset_path = os.path.join(output_path, f"{entry}.json")
-        with open(training_dataset_path, "w") as f:
-            json.dump(dataset_labeled, f, indent=4, default=default_handler)
-
-def process_statement(files, model_path=config.USE_MODEL_DIR):
-    # rewrite to take a single file, separate files
-    for entry in files:
-
-        file_path = os.path.join(config.INPUT_PDF_DIR, entry)
-        compliance_processed = pdf_to_text(file_path, model_path)
-
-        output_path = os.path.join(config.OUTPUT_JSON_DIR, f"{entry}.json")
-        with open(output_path, "w") as f:
-            json.dump(compliance_processed, f, indent=4, default=default_handler)
 
 def main():
-    process_tdata(TRAIN_FILES)
-    # train_model(config.TRAINING_DATA_DIR, config.USE_MODEL_DIR)
-    # process_statement(INPUT_FILES)
+    pipeline_config = CompliancePipelineConfig(
+        labeled_pdf_dir=config.LABELED_PDF_DIR,
+        training_data_dir=config.TRAINING_DATA_DIR,
+        input_pdf_dir=config.INPUT_PDF_DIR,
+        output_json_dir=config.OUTPUT_JSON_DIR,
+        inference_model_dir=config.USE_MODEL_DIR,
+        trained_model_dir=config.TRAINED_MODEL_DIR,
+    )
+
+    pipeline = CompliancePipeline(pdf_processing, data_labeler, model_trainer, pipeline_config)
+
+    training_files = [
+        entry for entry in os.listdir(pipeline_config.labeled_pdf_dir)
+        if os.path.isfile(os.path.join(pipeline_config.labeled_pdf_dir, entry))
+    ]
+    pipeline.build_training_data(training_files)
+    # pipeline.train()
+
+    input_files = [
+        entry for entry in os.listdir(pipeline_config.input_pdf_dir)
+        if os.path.isfile(os.path.join(pipeline_config.input_pdf_dir, entry))
+    ]
+    # pipeline.run_inference(input_files)
 
 
 if __name__ == "__main__":

--- a/sources/compliance_processor.py
+++ b/sources/compliance_processor.py
@@ -1,0 +1,109 @@
+"""Compliance processing pipeline utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+
+
+@dataclass
+class CompliancePipelineConfig:
+    """Configuration values used by :class:`CompliancePipeline`."""
+
+    labeled_pdf_dir: str
+    training_data_dir: str
+    input_pdf_dir: str
+    output_json_dir: str
+    inference_model_dir: str
+    trained_model_dir: Optional[str] = None
+
+
+class CompliancePipeline:
+    """Coordinate data extraction, training, and inference workflows."""
+
+    def __init__(self, pdf_processor, labeler, trainer, config: CompliancePipelineConfig):
+        self.pdf_processor = pdf_processor
+        self.labeler = labeler
+        self.trainer = trainer
+        self.config = config
+
+    @staticmethod
+    def default_handler(obj):
+        if isinstance(obj, np.floating):
+            return float(obj)
+        if isinstance(obj, np.integer):
+            return int(obj)
+        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+    def label_doc(self, text: Iterable[dict]):
+        unlabeled_data = []
+        for element in text:
+            unlabeled_data.append(
+                {
+                    "compliance_statement": element.get("compliance_statement"),
+                    "compliance_data": None,
+                    "date": None,
+                    "business_entity": None,
+                    "regulation": None,
+                    "text": element.get("text"),
+                }
+            )
+        return self.labeler.label_data(unlabeled_data)
+
+    def process_tdata(
+        self,
+        files: Sequence[str],
+        input_path: Optional[str] = None,
+        output_path: Optional[str] = None,
+    ):
+        input_dir = input_path or self.config.labeled_pdf_dir
+        output_dir = output_path or self.config.training_data_dir
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        for entry in files:
+            file_path = os.path.join(input_dir, entry)
+            dataset_labeled = self.pdf_processor.pdf_to_tdata(file_path)
+
+            training_dataset_path = os.path.join(output_dir, f"{entry}.json")
+            with open(training_dataset_path, "w") as f:
+                json.dump(dataset_labeled, f, indent=4, default=self.default_handler)
+
+    def process_statement(
+        self,
+        files: Sequence[str],
+        model_path: Optional[str] = None,
+        input_path: Optional[str] = None,
+        output_path: Optional[str] = None,
+    ):
+        input_dir = input_path or self.config.input_pdf_dir
+        output_dir = output_path or self.config.output_json_dir
+        model_dir = model_path or self.config.inference_model_dir
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        for entry in files:
+            file_path = os.path.join(input_dir, entry)
+            compliance_processed = self.pdf_processor.pdf_to_text(file_path, model_dir)
+
+            output_file_path = os.path.join(output_dir, f"{entry}.json")
+            with open(output_file_path, "w") as f:
+                json.dump(compliance_processed, f, indent=4, default=self.default_handler)
+
+    def build_training_data(self, files: Optional[Sequence[str]] = None):
+        training_files = files or os.listdir(self.config.labeled_pdf_dir)
+        self.process_tdata(training_files)
+
+    def train(self, **trainer_kwargs):
+        output_dir = self.config.trained_model_dir or self.config.inference_model_dir
+        return self.trainer.train_model(
+            self.config.training_data_dir, output_dir, **trainer_kwargs
+        )
+
+    def run_inference(self, files: Optional[Sequence[str]] = None):
+        inference_files = files or os.listdir(self.config.input_pdf_dir)
+        self.process_statement(inference_files)


### PR DESCRIPTION
## Summary
- add a CompliancePipeline class to coordinate training data prep, model training, and inference
- refactor main.py to instantiate the pipeline with configured directories and delegate to its methods

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5abf80c1483319230c9dc540b7484