### PR TITLE
Refactor PDF processing into service classes

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 
 import config
 from sources.compliance_processor import CompliancePipeline, CompliancePipelineConfig
-from sources import pdf_processing
+from sources.pdf_processing import PDFProcessor
 from sources import data_labeler
 from sources import model_trainer
 
@@ -17,7 +17,8 @@ def main():
         trained_model_dir=config.TRAINED_MODEL_DIR,
     )
 
-    pipeline = CompliancePipeline(pdf_processing, data_labeler, model_trainer, pipeline_config)
+    pdf_processor = PDFProcessor()
+    pipeline = CompliancePipeline(pdf_processor, data_labeler, model_trainer, pipeline_config)
 
     training_files = [
         entry for entry in os.listdir(pipeline_config.labeled_pdf_dir)

--- a/sources/compliance_processor.py
+++ b/sources/compliance_processor.py
@@ -67,7 +67,7 @@ class CompliancePipeline:
 
         for entry in files:
             file_path = os.path.join(input_dir, entry)
-            dataset_labeled = self.pdf_processor.pdf_to_tdata(file_path)
+            dataset_labeled = self.pdf_processor.to_training_data(file_path)
 
             training_dataset_path = os.path.join(output_dir, f"{entry}.json")
             with open(training_dataset_path, "w") as f:
@@ -88,7 +88,7 @@ class CompliancePipeline:
 
         for entry in files:
             file_path = os.path.join(input_dir, entry)
-            compliance_processed = self.pdf_processor.pdf_to_text(file_path, model_dir)
+            compliance_processed = self.pdf_processor.to_compliant_sentences(file_path, model_dir)
 
             output_file_path = os.path.join(output_dir, f"{entry}.json")
             with open(output_file_path, "w") as f:

--- a/sources/pdf_processing/__init__.py
+++ b/sources/pdf_processing/__init__.py
@@ -1,29 +1,73 @@
-from .image_processor import pdf_to_image
-from .tdata_extractor import image_to_tdata
-from .text_extractor import image_to_text
+"""PDF processing facade coordinating extraction and classification."""
+
+from __future__ import annotations
 
 import gc
+from typing import List, Optional
+
+import numpy as np
 import torch
 
-def pdf_to_tdata(pdf_path):
-    # Process all pages and consolidate results for training dataset
-    pages = pdf_to_image(pdf_path)
-    processed_text = image_to_tdata(pages)
-
-    clear_memory()
-    return processed_text
+from .image_processor import ImageProcessor
+from .sentence_processor import SentenceSegmenter
+from .tdata_extractor import TrainingDataExtractor
+from .text_extractor import SentenceClassifier
 
 
-def pdf_to_text(pdf_path, model_path):
-    # Process all pages, extract and classify the sentences
-    pages = pdf_to_image(pdf_path)
-    processed_text = image_to_text(pages, model_path)
+class PDFProcessor:
+    """Coordinate PDF image conversion, OCR, and sentence processing."""
 
-    clear_memory()
-    return [line for line, label in processed_text if label == 1]
+    def __init__(
+        self,
+        image_processor: Optional[ImageProcessor] = None,
+        sentence_segmenter: Optional[SentenceSegmenter] = None,
+        training_extractor: Optional[TrainingDataExtractor] = None,
+        sentence_classifier: Optional[SentenceClassifier] = None,
+    ):
+        self.image_processor = image_processor or ImageProcessor()
+        self.sentence_segmenter = sentence_segmenter or SentenceSegmenter()
+        self.training_extractor = training_extractor or TrainingDataExtractor(
+            self.image_processor, self.sentence_segmenter
+        )
+        self.sentence_classifier = sentence_classifier or SentenceClassifier()
+
+    def to_training_data(self, pdf_path: str) -> List[dict]:
+        """Process a PDF into labeled training data."""
+        results = self.training_extractor.extract_pages(pdf_path)
+        self._clear_memory()
+        return results
+
+    def to_compliant_sentences(self, pdf_path: str, model_dir: Optional[str] = None) -> List[str]:
+        """Extract sentences classified as compliant from a PDF."""
+        classifier = self.sentence_classifier
+        if model_dir and model_dir != classifier.model_dir:
+            classifier = SentenceClassifier(model_dir=model_dir)
+            self.sentence_classifier = classifier
+
+        sentences = self._extract_sentence_text(pdf_path)
+        classified = classifier.classify(sentences)
+        self._clear_memory()
+        return [text for text, label in classified if label == 1]
+
+    def _extract_sentence_text(self, pdf_path: str) -> List[str]:
+        sentences: List[str] = []
+        pages = self.image_processor.to_images(pdf_path)
+        for page in pages:
+            image = np.array(page)
+            ocr_results = self.image_processor.ocr(image, cls=False)
+            text_boxes = self.sentence_segmenter.extract_text_boxes(ocr_results)
+            segmented = self.sentence_segmenter.segment_sentences(text_boxes)
+            sentences.extend(
+                sentence["text"]
+                for sentence in segmented
+                if sentence.get("text")
+            )
+        return sentences
+
+    @staticmethod
+    def _clear_memory() -> None:
+        torch.cuda.empty_cache()
+        gc.collect()
 
 
-def clear_memory():
-    """Release GPU memory and clean up resources."""
-    torch.cuda.empty_cache()
-    gc.collect()
+__all__ = ["PDFProcessor"]

--- a/sources/pdf_processing/image_processor.py
+++ b/sources/pdf_processing/image_processor.py
@@ -1,16 +1,31 @@
-from pdf2image import convert_from_path
+"""Utilities for converting PDFs to images and running OCR."""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
 from paddleocr import PaddleOCR
+from pdf2image import convert_from_path
 
-DPI = 300
-OCR = PaddleOCR(lang='en')  # Use 'multilingual' for multi-language PDFs
 
-def pdf_to_image(pdf_path):
-    """Extract and consolidate text from a PDF, labeling compliance statements."""
-    try:
-        # Convert PDF to images (keep colors for highlight detection)
-        pages = convert_from_path(pdf_path, dpi=DPI)
-    except Exception as e:
-        print(f"Error converting PDF to images: {e}")
-        return []
+class ImageProcessor:
+    """Handle PDF page conversion and OCR extraction."""
 
-    return pages
+    def __init__(self, dpi: int = 300, ocr_lang: str = "en", **ocr_kwargs):
+        self.dpi = dpi
+        self._ocr = PaddleOCR(lang=ocr_lang, **ocr_kwargs)
+
+    def to_images(self, pdf_path: str) -> List:  # returns list of PIL Images
+        """Convert a PDF document into page images."""
+        try:
+            return convert_from_path(pdf_path, dpi=self.dpi)
+        except Exception as exc:  # pragma: no cover - logging side effect only
+            print(f"Error converting PDF to images: {exc}")
+            return []
+
+    def ocr(self, image, **ocr_kwargs) -> Sequence:
+        """Run OCR on an image and return raw PaddleOCR results."""
+        return self._ocr.ocr(image, **ocr_kwargs)
+
+
+__all__ = ["ImageProcessor"]

--- a/sources/pdf_processing/sentence_processor.py
+++ b/sources/pdf_processing/sentence_processor.py
@@ -1,82 +1,74 @@
-from .image_processor import OCR
+"""Sentence segmentation utilities for OCR output."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import spacy
 
-nlp = spacy.load("en_core_web_sm")  # Used for sentence segmentation
+
+class SentenceSegmenter:
+    """Convert OCR output into sentence-level annotations."""
+
+    def __init__(self, model: str = "en_core_web_sm"):
+        self._nlp = spacy.load(model)
+
+    @staticmethod
+    def _convert_bbox(paddle_bbox: Sequence[Sequence[float]]) -> List[float]:
+        x_min = min(point[0] for point in paddle_bbox)
+        y_min = min(point[1] for point in paddle_bbox)
+        x_max = max(point[0] for point in paddle_bbox)
+        y_max = max(point[1] for point in paddle_bbox)
+        return [x_min, y_min, x_max, y_max]
+
+    def extract_text_boxes(self, ocr_results: Sequence) -> List[Tuple[str, List[float]]]:
+        """Return text and bounding boxes from PaddleOCR results."""
+        if not ocr_results:
+            return []
+
+        extracted_data: List[Tuple[str, List[float]]] = []
+        for line in ocr_results[0]:
+            if len(line) < 2:
+                continue
+            bbox, (text, _conf) = line
+            if text.strip():
+                extracted_data.append((text, self._convert_bbox(bbox)))
+        return extracted_data
+
+    def segment_sentences(self, text_boxes: Iterable[Tuple[str, List[float]]]) -> List[dict]:
+        """Segment OCR words into sentences with merged bounding boxes."""
+        words: List[str] = []
+        bounding_boxes: List[List[float]] = []
+        for text, bbox in text_boxes:
+            words.append(text)
+            bounding_boxes.append(bbox)
+
+        if not words:
+            return []
+
+        full_text = " ".join(words)
+        doc = self._nlp(full_text)
+
+        sentences: List[dict] = []
+        for sent in doc.sents:
+            sentence_text = sent.text.strip()
+            matched_boxes: List[List[float]] = []
+            for word, bbox in zip(words, bounding_boxes):
+                if word in sentence_text:
+                    matched_boxes.append(bbox)
+
+            if matched_boxes:
+                x_min = min(box[0] for box in matched_boxes)
+                y_min = min(box[1] for box in matched_boxes)
+                x_max = max(box[2] for box in matched_boxes)
+                y_max = max(box[3] for box in matched_boxes)
+                sentence_bbox: Optional[List[float]] = [x_min, y_min, x_max, y_max]
+            else:
+                sentence_bbox = None
+
+            sentences.append({"text": sentence_text, "bounding_box": sentence_bbox})
+
+        return sentences
 
 
-def extract_bbox(image):
-    """Extract bounding boxes and text using OCR."""
-    ocr_results = OCR.ocr(image, cls=False)
-    
-    print(ocr_results)
-
-    extracted_data = []
-    for line in ocr_results[0]:
-        if len(line) < 2:
-            continue  # Skip malformed OCR results
-
-        bbox, (text, conf) = line
-        if text.strip():  # Ensure non-empty text
-            extracted_data.append((text, bbox))
-    
-    return extracted_data if extracted_data else None  # Avoid returning NULL
-
-def convert_bbox(paddle_bbox):
-    """Convert PaddleOCR bounding box format (4 points) to (x_min, y_min, x_max, y_max)."""
-    x_min = min(point[0] for point in paddle_bbox)
-    y_min = min(point[1] for point in paddle_bbox)
-    x_max = max(point[0] for point in paddle_bbox)
-    y_max = max(point[1] for point in paddle_bbox)
-    return [x_min, y_min, x_max, y_max]
-
-
-def segment_sentences(text_boxes):
-    sentences = []
-    words = [item[0] for item in text_boxes]  # Extract words only
-    bounding_boxes = [item[1] for item in text_boxes]  # Extract bounding boxes
-
-    # Join words into a full text passage
-    full_text = " ".join(words)
-
-    # Use spaCy to split into sentences
-    doc = nlp(full_text)
-    for sent in doc.sents:
-        sentence_text = sent.text.strip()
-
-        # Find words that belong to this sentence
-        matched_boxes = []
-        for word, bbox in zip(words, bounding_boxes):
-            if word in sentence_text:
-                matched_boxes.append(bbox)
-
-        # Merge bounding boxes for sentence
-        if matched_boxes:
-            x_min = min(box[0][0] for box in matched_boxes)  # Left-most x
-            y_min = min(box[0][1] for box in matched_boxes)  # Top-most y
-            x_max = max(box[2][0] for box in matched_boxes)  # Right-most x
-            y_max = max(box[2][1] for box in matched_boxes)  # Bottom-most y
-
-            sentence_bbox = (x_min, y_min, x_max, y_max)
-        else:
-            sentence_bbox = None  # Avoid NULL values
-
-        # **Use dictionary instead of tuple**
-        sentences.append({
-            "text": sentence_text,
-            "bounding_box": sentence_bbox
-        })
-
-    return sentences
-
-
-def find_sentence_box(sentence, text_boxes):
-    """Find a bounding box that covers a given sentence based on text box locations."""
-    matching_boxes = [box["bounding_box"] for box in text_boxes if sentence in box["text"]]
-    if not matching_boxes:
-        return None
-    x_min = min(box[0] for box in matching_boxes)
-    y_min = min(box[1] for box in matching_boxes)
-    x_max = max(box[2] for box in matching_boxes)
-    y_max = max(box[3] for box in matching_boxes)
-    return [x_min, y_min, x_max, y_max]
+__all__ = ["SentenceSegmenter"]

--- a/sources/pdf_processing/tdata_extractor.py
+++ b/sources/pdf_processing/tdata_extractor.py
@@ -1,72 +1,96 @@
-from .image_processor import OCR
-from .sentence_processor import extract_bbox, segment_sentences
+"""Training data extraction utilities."""
 
-import numpy as np
+from __future__ import annotations
+
+from typing import List, Sequence
+
 import cv2
-import spacy
+import numpy as np
 
-nlp = spacy.load("en_core_web_sm")  # Used for sentence segmentation
-
-
-def detect_highlighted_regions(image):
-    """Detect highlighted regions in the image using color detection."""
-    hsv = cv2.cvtColor(image, cv2.COLOR_RGB2HSV)
-    lower_highlight = np.array([90, 50, 200])
-    upper_highlight = np.array([130, 255, 255])
-    mask = cv2.inRange(hsv, lower_highlight, upper_highlight)
-    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    return [[x, y, x + w, y + h] for x, y, w, h in (cv2.boundingRect(contour) for contour in contours)]
+from .image_processor import ImageProcessor
+from .sentence_processor import SentenceSegmenter
 
 
-def label_compliance_sentences(sentences, highlighted_boxes, iou_threshold=0.5):
-    """Label sentences as compliance_statement=1 or compliance_statement=0 based on IoU with highlighted regions."""
-    for sentence in sentences:
-        if sentence["bounding_box"]:
-            x, y, x2, y2 = sentence["bounding_box"]
-            sentence["compliance_statement"] = int(any(
-                calculate_iou([x, y, x2, y2], [hx, hy, hx + hw, hy + hh]) > iou_threshold
-                for hx, hy, hw, hh in highlighted_boxes
-            ))
-        else:
-            sentence["compliance_statement"] = 0
-    return sentences
+class TrainingDataExtractor:
+    """Generate labeled training examples from PDF pages."""
+
+    def __init__(self, image_processor: ImageProcessor, sentence_segmenter: SentenceSegmenter):
+        self.image_processor = image_processor
+        self.sentence_segmenter = sentence_segmenter
+
+    def extract_pages(self, pdf_path: str) -> List[dict]:
+        """Extract and label sentences from a PDF file."""
+        pages = self.image_processor.to_images(pdf_path)
+        consolidated_results: List[dict] = []
+
+        for page in pages:
+            image = np.array(page)
+            ocr_results = self.image_processor.ocr(image, cls=False)
+            text_boxes = self.sentence_segmenter.extract_text_boxes(ocr_results)
+            sentences = self.sentence_segmenter.segment_sentences(text_boxes)
+
+            highlighted_boxes = self._detect_highlighted_regions(image)
+            labeled_text = self.label_sentences(sentences, highlighted_boxes)
+            consolidated_results.extend(labeled_text)
+
+        return consolidated_results
+
+    def label_sentences(
+        self,
+        sentences: Sequence[dict],
+        highlighted_boxes: Sequence[Sequence[float]],
+        iou_threshold: float = 0.5,
+    ) -> List[dict]:
+        """Apply compliance labels to sentences based on highlight overlap."""
+        labeled_sentences: List[dict] = []
+        for sentence in sentences:
+            bbox = sentence.get("bounding_box")
+            if bbox:
+                sentence_box = [bbox[0], bbox[1], bbox[2], bbox[3]]
+                compliance = int(
+                    any(
+                        self._calculate_iou(sentence_box, highlight_box) > iou_threshold
+                        for highlight_box in highlighted_boxes
+                    )
+                )
+            else:
+                compliance = 0
+
+            labeled_sentence = dict(sentence)
+            labeled_sentence["compliance_statement"] = compliance
+            labeled_sentences.append(labeled_sentence)
+
+        return labeled_sentences
+
+    @staticmethod
+    def _detect_highlighted_regions(image: np.ndarray) -> List[List[int]]:
+        hsv = cv2.cvtColor(image, cv2.COLOR_RGB2HSV)
+        lower_highlight = np.array([90, 50, 200])
+        upper_highlight = np.array([130, 255, 255])
+        mask = cv2.inRange(hsv, lower_highlight, upper_highlight)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        boxes: List[List[int]] = []
+        for contour in contours:
+            x, y, w, h = cv2.boundingRect(contour)
+            boxes.append([x, y, x + w, y + h])
+        return boxes
+
+    @staticmethod
+    def _calculate_iou(box1: Sequence[float], box2: Sequence[float]) -> float:
+        if not box1 or not box2:
+            return 0.0
+
+        x1, y1 = max(box1[0], box2[0]), max(box1[1], box2[1])
+        x2, y2 = min(box1[2], box2[2]), min(box1[3], box2[3])
+
+        intersection = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+        area1 = max(0.0, box1[2] - box1[0]) * max(0.0, box1[3] - box1[1])
+        area2 = max(0.0, box2[2] - box2[0]) * max(0.0, box2[3] - box2[1])
+        union = area1 + area2 - intersection
+
+        if union <= 0:
+            return 0.0
+        return intersection / union
 
 
-def calculate_iou(box1, box2):
-    """Calculate Intersection over Union (IoU) for two bounding boxes."""
-    if not box1 or not box2 or len(box1) != 4 or len(box2) != 4:
-        return 0
-    x1, y1 = max(box1[0], box2[0]), max(box1[1], box2[1])
-    x2, y2 = min(box1[2], box2[2]), min(box1[3], box2[3])
-
-    intersection = max(0, x2 - x1) * max(0, y2 - y1)
-
-    area1 = (box1[2] - box1[0]) * (box1[3] - box1[1])
-    area2 = (box2[2] - box2[0]) * (box2[3] - box2[1])
-
-    union = area1 + area2 - intersection
-
-    return intersection / union if union > 0 else 0
-
-
-def image_to_tdata(pages):
-    consolidated_results = []
-    
-    for page in pages:
-        # Convert page to NumPy array
-        image = np.array(page)
-
-        # Extracts text and converts it into senteces
-        text_boxes = extract_bbox(image)
-        sentences = segment_sentences(text_boxes)
-
-        highlighted_boxes = detect_highlighted_regions(image)
-        # Detect highlighted regions 
-        labeled_text = label_compliance_sentences(sentences, highlighted_boxes)
-
-        #print("test")
-
-        # Add labeled text to consolidated results
-        consolidated_results.extend(labeled_text)
-
-    return consolidated_results 
+__all__ = ["TrainingDataExtractor"]

--- a/sources/pdf_processing/text_extractor.py
+++ b/sources/pdf_processing/text_extractor.py
@@ -1,66 +1,70 @@
+"""Sentence classification utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Optional, Tuple
+
+import torch
+from torch import cuda
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
 import config
 
-from .image_processor import OCR
-from .sentence_processor import segment_sentences
 
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-from torch import cuda
-import torch
+class SentenceClassifier:
+    """Classify sentences for compliance using a transformer model."""
 
-import numpy as np
+    def __init__(
+        self,
+        model_dir: Optional[str] = None,
+        device_resolver: Optional[Callable[[], str]] = None,
+    ):
+        self.model_dir = model_dir or config.USE_MODEL_DIR
+        self.device_resolver = device_resolver or self._default_device_resolver
+        self._tokenizer: Optional[AutoTokenizer] = None
+        self._model: Optional[AutoModelForSequenceClassification] = None
+        self._device: Optional[torch.device] = None
 
-tokenizer = AutoTokenizer.from_pretrained(config.USE_MODEL_DIR)
-model = AutoModelForSequenceClassification.from_pretrained(config.USE_MODEL_DIR)
+    @staticmethod
+    def _default_device_resolver() -> str:
+        return "cuda" if cuda.is_available() else "cpu"
 
-# Check if a GPU is available and move the model to the GPU
-device = "cuda" if cuda.is_available() else "cpu"
-model = model.to(device)
+    def _ensure_model(self) -> None:
+        if self._tokenizer is not None and self._model is not None and self._device is not None:
+            return
 
-def classify_sentences(model, tokenizer, sentences, batch_size=32):
-    """Classify sentences as compliant or not compliant in batches."""
-    device = model.device  # Automatically get the model's device
-    valid_sentences = [s for s in sentences if isinstance(s, str) and s.strip()]
-    predictions = []
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_dir)
+        self._model = AutoModelForSequenceClassification.from_pretrained(self.model_dir)
+        device = torch.device(self.device_resolver())
+        self._device = device
+        self._model = self._model.to(device)
 
-    for i in range(0, len(valid_sentences), batch_size):
-        batch = valid_sentences[i:i + batch_size]
+    def classify(self, sentences: Iterable[str], batch_size: int = 32) -> List[Tuple[str, int]]:
+        """Classify an iterable of sentences as compliant or not."""
+        self._ensure_model()
+        assert self._tokenizer is not None and self._model is not None and self._device is not None
 
-        # Tokenize the batch
-        tokenized_batch = tokenizer(batch, truncation=True, padding="max_length", return_tensors="pt")
+        valid_sentences = [s for s in sentences if isinstance(s, str) and s.strip()]
+        predictions: List[int] = []
 
-        # Move input tensors to the same device as the model
-        tokenized_batch = {k: v.to(device) for k, v in tokenized_batch.items()}
+        for start in range(0, len(valid_sentences), batch_size):
+            batch = valid_sentences[start : start + batch_size]
+            tokenized = self._tokenizer(
+                batch,
+                truncation=True,
+                padding="max_length",
+                return_tensors="pt",
+            )
+            tokenized = {key: value.to(self._device) for key, value in tokenized.items()}
 
-        # Perform inference
-        with torch.no_grad():  # Disable gradient computation for inference
-            outputs = model(**tokenized_batch)
-            logits = outputs.logits
-            batch_predictions = logits.argmax(dim=-1).tolist()
+            with torch.no_grad():
+                outputs = self._model(**tokenized)
+                logits = outputs.logits
+                batch_predictions = logits.argmax(dim=-1).tolist()
 
-        predictions.extend(batch_predictions)
+            predictions.extend(batch_predictions)
 
-    # Pair sentences with predictions
-    return [(sentence, label) for sentence, label in zip(valid_sentences, predictions)]
+        return list(zip(valid_sentences, predictions))
 
 
-def image_to_text(pages):
-    sentences = []
-
-    for page in pages:
-        print(f"Processing page: {page}")
-        image = np.array(page)
-        ocr_results = OCR.ocr(image, cls=False)
-
-        # Extract text content and bounding boxes
-        text_boxes = [(line[1][0], line[0]) for line in ocr_results[0]]
-
-        # Segment text into sentences
-        segmented_sentences = segment_sentences(text_boxes)
-
-        # Collect sentences for classification
-        sentences.extend([s[0] for s in segmented_sentences])  # Extract text content only
-    
-    classified_sentences = classify_sentences(model, tokenizer, sentences)
-    print(classified_sentences)
-
-    return classified_sentences
+__all__ = ["SentenceClassifier"]


### PR DESCRIPTION
## Summary
- wrap PDF conversion and OCR logic in an ImageProcessor service and add a SentenceSegmenter helper
- introduce TrainingDataExtractor and SentenceClassifier classes to modularize training-data extraction and sentence classification
- add a PDFProcessor facade and update the pipeline wiring to use the new class-based architecture

## Testing
- python -m compileall sources/pdf_processing main.py sources/compliance_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ae31287883319ba22664b22ae17f