### PR TITLE
Refactor training pipeline into ModelTrainer class

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import config
 from sources.compliance_processor import CompliancePipeline, CompliancePipelineConfig
 from sources.data_labeler import DateLabeler, EntityLabeler, LabelingPipeline, PartLabeler, RegulationLabeler
 from sources.pdf_processing import PDFProcessor
-from sources import model_trainer
+from sources.model_trainer import ModelTrainer
 
 
 def build_labeling_pipeline() -> LabelingPipeline:
@@ -29,7 +29,12 @@ def main():
 
     pdf_processor = PDFProcessor()
     labeling_pipeline = build_labeling_pipeline()
-    pipeline = CompliancePipeline(pdf_processor, labeling_pipeline, model_trainer, pipeline_config)
+    trainer = ModelTrainer(
+        training_data_dir=pipeline_config.training_data_dir,
+        output_dir=pipeline_config.trained_model_dir or pipeline_config.inference_model_dir,
+    )
+
+    pipeline = CompliancePipeline(pdf_processor, labeling_pipeline, trainer, pipeline_config)
 
     training_files = [
         entry for entry in os.listdir(pipeline_config.labeled_pdf_dir)

--- a/sources/model_trainer.py
+++ b/sources/model_trainer.py
@@ -1,108 +1,189 @@
-import os
+"""Utilities for training and evaluating sequence classification models."""
+
+from __future__ import annotations
+
 import json
+import os
 import random
-from transformers import AutoTokenizer, AutoModelForSequenceClassification, Trainer, TrainingArguments
-from sklearn.model_selection import train_test_split
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
 from datasets import Dataset, DatasetDict
 from sklearn.metrics import accuracy_score, precision_recall_fscore_support
+from sklearn.model_selection import train_test_split
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+)
 
-# Prepare dataset with oversampling
-def prepare_oversampled_dataset(data_dir):
-    texts, labels = [], []
 
-    # Load data
-    for file_name in filter(lambda f: f.endswith(".json"), os.listdir(data_dir)):
-        with open(os.path.join(data_dir, file_name), "r") as f:
-            data = json.load(f)
-            for item in data:
-                texts.append(item["text"])
-                labels.append(item.get("compliance_statement", 0))
+@dataclass
+class ModelTrainer:
+    """Train and evaluate transformer-based sequence classification models."""
 
-    # Separate majority and minority classes
-    majority_class = [(t, l) for t, l in zip(texts, labels) if l == 0]
-    minority_class = [(t, l) for t, l in zip(texts, labels) if l == 1]
+    training_data_dir: str
+    output_dir: str
+    model_name: str = "nlpaueb/legal-bert-base-uncased"
+    tokenizer_name: Optional[str] = None
+    epochs: int = 3
+    batch_size: int = 32
+    learning_rate: float = 2e-5
+    weight_decay: float = 0.01
+    logging_dir: str = "./logs"
+    logging_steps: int = 10
+    gradient_accumulation_steps: int = 2
+    dataloader_num_workers: int = 4
+    fp16: bool = True
+    test_size: float = 0.2
+    random_state: int = 42
+    training_args_overrides: Dict[str, object] = field(default_factory=dict)
 
-    # Oversample the minority class to match the majority class size
-    oversampled_minority_class = random.choices(minority_class, k=len(majority_class))
+    def __post_init__(self) -> None:
+        self.tokenizer_name = self.tokenizer_name or self.model_name
+        self._tokenizer = None
+        self._model = None
+        self._tokenized_datasets: Optional[DatasetDict] = None
+        self._trainer: Optional[Trainer] = None
 
-    # Combine the oversampled minority class with the majority class
-    balanced_data = majority_class + oversampled_minority_class
-    random.shuffle(balanced_data)
+    @property
+    def tokenizer(self):
+        if self._tokenizer is None:
+            self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
+        return self._tokenizer
 
-    balanced_texts, balanced_labels = zip(*balanced_data)
-    return list(balanced_texts), list(balanced_labels)
+    @property
+    def model(self):
+        if self._model is None:
+            self._model = AutoModelForSequenceClassification.from_pretrained(
+                self.model_name, num_labels=2
+            )
+        return self._model
 
-# Tokenize dataset
-def tokenize_dataset(dataset, tokenizer):
-    return dataset.map(lambda x: tokenizer(x["text"], truncation=True, padding="max_length"), batched=True)
+    def prepare_dataset(self) -> DatasetDict:
+        """Load raw data, apply oversampling, split, and tokenize."""
 
-# Compute metrics
-def compute_metrics(eval_pred):
-    logits, labels = eval_pred
-    preds = logits.argmax(axis=-1)
-    precision, recall, f1, _ = precision_recall_fscore_support(labels, preds, average="binary")
-    acc = accuracy_score(labels, preds)
-    return {"accuracy": acc, "f1": f1, "precision": precision, "recall": recall}
+        texts, labels = self._prepare_oversampled_dataset(self.training_data_dir)
+        train_texts, val_texts, train_labels, val_labels = train_test_split(
+            texts,
+            labels,
+            test_size=self.test_size,
+            random_state=self.random_state,
+        )
 
-# Train model
-def train_model(data_dir, output_dir, model_name="nlpaueb/legal-bert-base-uncased", epochs=3, batch_size=32):
-    # Prepare data with oversampling
-    texts, labels = prepare_oversampled_dataset(data_dir)
-    train_texts, val_texts, train_labels, val_labels = train_test_split(texts, labels, test_size=0.2, random_state=42)
+        datasets = DatasetDict(
+            {
+                "train": Dataset.from_dict({"text": train_texts, "label": train_labels}),
+                "validation": Dataset.from_dict(
+                    {"text": val_texts, "label": val_labels}
+                ),
+            }
+        )
 
-    datasets = DatasetDict({
-        "train": Dataset.from_dict({"text": train_texts, "label": train_labels}),
-        "validation": Dataset.from_dict({"text": val_texts, "label": val_labels})
-    })
+        tokenized = self._tokenize_dataset(datasets)
+        tokenized.set_format("torch", columns=["input_ids", "attention_mask", "label"])
+        self._tokenized_datasets = tokenized
+        return tokenized
 
-    # Initialize tokenizer and model
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=2)
+    def train(self, **training_overrides) -> Trainer:
+        """Train the configured model and persist artifacts."""
 
-    # Tokenize datasets
-    tokenized_datasets = tokenize_dataset(datasets, tokenizer)
-    tokenized_datasets.set_format("torch", columns=["input_ids", "attention_mask", "label"])
+        tokenized_datasets = self._tokenized_datasets or self.prepare_dataset()
+        os.makedirs(self.output_dir, exist_ok=True)
 
-    # Training arguments
-    training_args = TrainingArguments(
-        output_dir=output_dir,
-        evaluation_strategy="epoch",
-        save_strategy="epoch",
-        learning_rate=2e-5,
-        per_device_train_batch_size=batch_size,
-        per_device_eval_batch_size=batch_size,
-        num_train_epochs=epochs,
-        weight_decay=0.01,
-        logging_dir="./logs",
-        logging_steps=10,
-        load_best_model_at_end=True,
-        metric_for_best_model="f1",
-        fp16=True,  # Mixed precision
-        gradient_accumulation_steps=2,
-        dataloader_num_workers=4,
-    )
+        training_arguments = self._build_training_arguments(training_overrides)
 
-    # Initialize Trainer
-    trainer = Trainer(
-        model=model,
-        args=training_args,
-        train_dataset=tokenized_datasets["train"],
-        eval_dataset=tokenized_datasets["validation"],
-        tokenizer=tokenizer,
-        compute_metrics=compute_metrics,
-    )
+        trainer = Trainer(
+            model=self.model,
+            args=training_arguments,
+            train_dataset=tokenized_datasets["train"],
+            eval_dataset=tokenized_datasets["validation"],
+            tokenizer=self.tokenizer,
+            compute_metrics=self._compute_metrics,
+        )
 
-    # Train and save model
-    trainer.train()
-    trainer.save_model(output_dir)
-    tokenizer.save_pretrained(output_dir)
+        trainer.train()
+        trainer.save_model(self.output_dir)
+        self.tokenizer.save_pretrained(self.output_dir)
 
-    # Evaluate the model on the validation set
-    eval_metrics = trainer.evaluate()
-    
-    # Save metrics to a JSON file
-    metrics_file_path = os.path.join(output_dir, "metrics.json")
-    with open(metrics_file_path, "w") as metrics_file:
-        json.dump(eval_metrics, metrics_file, indent=4)
+        self._trainer = trainer
+        return trainer
 
-    return trainer
+    def evaluate(self, save: bool = True) -> Dict[str, float]:
+        """Evaluate the trained model on the validation split."""
+
+        if self._trainer is None:
+            raise RuntimeError("The model must be trained before evaluation.")
+
+        metrics = self._trainer.evaluate()
+        if save:
+            metrics_path = os.path.join(self.output_dir, "metrics.json")
+            with open(metrics_path, "w") as metrics_file:
+                json.dump(metrics, metrics_file, indent=4)
+        return metrics
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    def _prepare_oversampled_dataset(self, data_dir: str):
+        texts, labels = [], []
+
+        for file_name in filter(lambda f: f.endswith(".json"), os.listdir(data_dir)):
+            with open(os.path.join(data_dir, file_name), "r") as f:
+                data = json.load(f)
+                for item in data:
+                    texts.append(item["text"])
+                    labels.append(item.get("compliance_statement", 0))
+
+        majority_class = [(t, l) for t, l in zip(texts, labels) if l == 0]
+        minority_class = [(t, l) for t, l in zip(texts, labels) if l == 1]
+
+        if not minority_class:
+            raise ValueError("No positive class examples found for oversampling.")
+
+        oversampled_minority_class = random.choices(minority_class, k=len(majority_class))
+
+        balanced_data = majority_class + oversampled_minority_class
+        random.shuffle(balanced_data)
+
+        balanced_texts, balanced_labels = zip(*balanced_data)
+        return list(balanced_texts), list(balanced_labels)
+
+    def _tokenize_dataset(self, dataset: DatasetDict) -> DatasetDict:
+        return dataset.map(
+            lambda x: self.tokenizer(
+                x["text"], truncation=True, padding="max_length"
+            ),
+            batched=True,
+        )
+
+    def _compute_metrics(self, eval_pred):
+        logits, labels = eval_pred
+        preds = logits.argmax(axis=-1)
+        precision, recall, f1, _ = precision_recall_fscore_support(
+            labels, preds, average="binary"
+        )
+        acc = accuracy_score(labels, preds)
+        return {"accuracy": acc, "f1": f1, "precision": precision, "recall": recall}
+
+    def _build_training_arguments(self, overrides: Dict[str, object]) -> TrainingArguments:
+        training_kwargs = {
+            "evaluation_strategy": "epoch",
+            "save_strategy": "epoch",
+            "learning_rate": self.learning_rate,
+            "per_device_train_batch_size": self.batch_size,
+            "per_device_eval_batch_size": self.batch_size,
+            "num_train_epochs": self.epochs,
+            "weight_decay": self.weight_decay,
+            "logging_dir": self.logging_dir,
+            "logging_steps": self.logging_steps,
+            "load_best_model_at_end": True,
+            "metric_for_best_model": "f1",
+            "fp16": self.fp16,
+            "gradient_accumulation_steps": self.gradient_accumulation_steps,
+            "dataloader_num_workers": self.dataloader_num_workers,
+        }
+        training_kwargs.update(self.training_args_overrides)
+        training_kwargs.update(overrides)
+        return TrainingArguments(output_dir=self.output_dir, **training_kwargs)


### PR DESCRIPTION
## Summary
- replace the training module-level helpers with a configurable ModelTrainer class that manages dataset preparation, training, and evaluation
- update CompliancePipeline to rely on the ModelTrainer instance and expose evaluation control
- instantiate the new trainer in the main entrypoint using configuration paths

## Testing
- python -m compileall sources main.py

------
https://chatgpt.com/codex/tasks/task_e_68d5b37e39688331927b478867bf384b